### PR TITLE
Fixed chinook namespace casing

### DIFF
--- a/src/AsyncWebView.Uno/AsyncWebView.Uno.csproj
+++ b/src/AsyncWebView.Uno/AsyncWebView.Uno.csproj
@@ -5,12 +5,12 @@
 		<TargetFrameworks Condition="'!$([MSBuild]::IsOsPlatform(OSX))'">netstandard2.0;xamarinios10;monoandroid10.0;uap10.0.17763</TargetFrameworks>
 		<!-- Ensures the .xr.xml files are generated in a proper layout folder -->
 		<GenerateLibraryLayout>true</GenerateLibraryLayout>
-		<RootNamespace>chinook.AsyncWebView</RootNamespace>
+		<RootNamespace>Chinook.AsyncWebView</RootNamespace>
 		<Authors>nventive</Authors>
 		<Company>nventive</Company>
-		<AssemblyName>chinook.AsyncWebView.Uno</AssemblyName>
-		<PackageId>chinook.AsyncWebView.Uno</PackageId>
-		<Description>chinook.AsyncWebView.Uno</Description>
+		<AssemblyName>Chinook.AsyncWebView.Uno</AssemblyName>
+		<PackageId>Chinook.AsyncWebView.Uno</PackageId>
+		<Description>Chinook.AsyncWebView.Uno</Description>
 		<GenerateDocumentationFile>true</GenerateDocumentationFile>
   </PropertyGroup>
 

--- a/src/AsyncWebView.Uno/AsyncWebView/AsyncWebView.Android.cs
+++ b/src/AsyncWebView.Uno/AsyncWebView/AsyncWebView.Android.cs
@@ -8,7 +8,7 @@ using Microsoft.Extensions.Logging;
 using Windows.UI.Xaml;
 using Windows.UI.Xaml.Media;
 
-namespace chinook.AsyncWebView
+namespace Chinook.AsyncWebView
 {
 	/// <summary>
 	/// Implementation of <see cref="AsyncWebView"/> for Android

--- a/src/AsyncWebView.Uno/AsyncWebView/AsyncWebView.Commands.cs
+++ b/src/AsyncWebView.Uno/AsyncWebView/AsyncWebView.Commands.cs
@@ -4,7 +4,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Extensions.Logging;
 
-namespace chinook.AsyncWebView
+namespace Chinook.AsyncWebView
 {
 	/// <summary>
 	/// Implementation of <see href="AsyncWebView" /> active commands

--- a/src/AsyncWebView.Uno/AsyncWebView/AsyncWebView.Properties.cs
+++ b/src/AsyncWebView.Uno/AsyncWebView/AsyncWebView.Properties.cs
@@ -9,7 +9,7 @@ using Windows.Web.Http;
 using System.Net.Http;
 #endif
 
-namespace chinook.AsyncWebView
+namespace Chinook.AsyncWebView
 {
 	/// <summary>
 	/// Implementation of <see cref="AsyncWebView"/> properties

--- a/src/AsyncWebView.Uno/AsyncWebView/AsyncWebView.UWP.cs
+++ b/src/AsyncWebView.Uno/AsyncWebView/AsyncWebView.UWP.cs
@@ -6,7 +6,7 @@ using Microsoft.Extensions.Logging;
 using Windows.UI.Xaml.Controls;
 using Windows.Web.Http.Filters;
 
-namespace chinook.AsyncWebView
+namespace Chinook.AsyncWebView
 {
 	/// <summary>
 	/// Implementation of <see cref="AsyncWebView"/> for Windows

--- a/src/AsyncWebView.Uno/AsyncWebView/AsyncWebView.Wasm.cs
+++ b/src/AsyncWebView.Uno/AsyncWebView/AsyncWebView.Wasm.cs
@@ -2,7 +2,7 @@
 using System.Threading;
 using System.Threading.Tasks;
 
-namespace chinook.AsyncWebView
+namespace Chinook.AsyncWebView
 {
 	/// <summary>
 	/// Implementation of <see cref="AsyncWebView" /> for WASM.

--- a/src/AsyncWebView.Uno/AsyncWebView/AsyncWebView.cs
+++ b/src/AsyncWebView.Uno/AsyncWebView/AsyncWebView.cs
@@ -13,7 +13,7 @@ using Windows.UI.Xaml.Controls;
 using Microsoft.Extensions.Logging.Abstractions;
 using System.Linq;
 
-namespace chinook.AsyncWebView
+namespace Chinook.AsyncWebView
 {
 	/// <summary>
 	/// Encapsulates a WebView control and adds multiple navigation handling scenarios.

--- a/src/AsyncWebView.Uno/AsyncWebView/AsyncWebView.iOS.cs
+++ b/src/AsyncWebView.Uno/AsyncWebView/AsyncWebView.iOS.cs
@@ -5,7 +5,7 @@ using Foundation;
 using Microsoft.Extensions.Logging;
 using WebKit;
 
-namespace chinook.AsyncWebView
+namespace Chinook.AsyncWebView
 {
 	/// <summary>
 	/// Implementation of <see cref="AsyncWebView"/> for iOS

--- a/src/AsyncWebView.Uno/AsyncWebViewConstants.cs
+++ b/src/AsyncWebView.Uno/AsyncWebViewConstants.cs
@@ -1,4 +1,4 @@
-﻿namespace chinook.AsyncWebView
+﻿namespace Chinook.AsyncWebView
 {
 	public static class AsyncWebViewConstants
 	{

--- a/src/AsyncWebView.Uno/Entities/VisualStates.cs
+++ b/src/AsyncWebView.Uno/Entities/VisualStates.cs
@@ -1,4 +1,4 @@
-﻿namespace chinook.AsyncWebView
+﻿namespace Chinook.AsyncWebView
 {
 	public static class VisualStates
 	{

--- a/src/AsyncWebView.Uno/Extensions/StringExtensions.cs
+++ b/src/AsyncWebView.Uno/Extensions/StringExtensions.cs
@@ -1,6 +1,6 @@
 ﻿using System;
 
-namespace chinook.AsyncWebView
+namespace Chinook.AsyncWebView
 {
 	public static class StringExtensions
 	{

--- a/src/AsyncWebView.Uno/Extensions/WebViewExtensions.cs
+++ b/src/AsyncWebView.Uno/Extensions/WebViewExtensions.cs
@@ -7,7 +7,7 @@ using Windows.UI.Xaml;
 using Windows.UI.Xaml.Controls;
 using _WebView = Windows.UI.Xaml.Controls.WebView;
 
-namespace chinook.AsyncWebView
+namespace Chinook.AsyncWebView
 {
 	/// <summary>
 	/// Encapsulates extensions for webview

--- a/src/AsyncWebView.Uno/Helpers/CompletionCommandArgs.cs
+++ b/src/AsyncWebView.Uno/Helpers/CompletionCommandArgs.cs
@@ -3,7 +3,7 @@ using System;
 using System.Threading;
 using System.Threading.Tasks;
 
-namespace chinook.AsyncWebView
+namespace Chinook.AsyncWebView
 {
 	/// <summary>
 	/// Encapsulates completion command arguments

--- a/src/AsyncWebView.Uno/Helpers/ControlState.cs
+++ b/src/AsyncWebView.Uno/Helpers/ControlState.cs
@@ -1,6 +1,6 @@
 ﻿using System;
 
-namespace chinook.AsyncWebView
+namespace Chinook.AsyncWebView
 {
 	[Flags]
 	internal enum ControlState

--- a/src/AsyncWebView.Uno/Helpers/ControlStateManager.cs
+++ b/src/AsyncWebView.Uno/Helpers/ControlStateManager.cs
@@ -1,8 +1,8 @@
 ﻿using System;
 using System.Collections.Generic;
-using Trigger = System.Tuple<chinook.AsyncWebView.ControlState, chinook.AsyncWebView.ControlState, System.Action>;
+using Trigger = System.Tuple<Chinook.AsyncWebView.ControlState, Chinook.AsyncWebView.ControlState, System.Action>;
 
-namespace chinook.AsyncWebView
+namespace Chinook.AsyncWebView
 {
 	internal partial class ControlStateManager
 	{

--- a/src/AsyncWebView.Uno/Helpers/NavigationMode.cs
+++ b/src/AsyncWebView.Uno/Helpers/NavigationMode.cs
@@ -1,4 +1,4 @@
-﻿namespace chinook.AsyncWebView
+﻿namespace Chinook.AsyncWebView
 {
 	/// <summary>
 	/// Specifies how links inside the AsyncWebView should be opened.

--- a/src/AsyncWebView.Uno/Helpers/WebViewCommand.cs
+++ b/src/AsyncWebView.Uno/Helpers/WebViewCommand.cs
@@ -3,7 +3,7 @@ using System.Collections.Generic;
 using System.Text;
 using System.Windows.Input;
 
-namespace chinook.AsyncWebView
+namespace Chinook.AsyncWebView
 {
 	internal class WebViewCommand : ICommand
 	{


### PR DESCRIPTION
GitHub Issue: #
<!-- Link to relevant GitHub issue if applicable.
     All PRs should be associated with an issue -->

## Proposed Changes
<!-- Please un-comment one ore more that apply to this PR -->

- Bug fix
<!-- - Feature -->
<!-- - Code style update (formatting) -->
<!-- - Refactoring (no functional changes, no api changes) -->
<!-- - Build or CI related changes -->
<!-- - Documentation content changes -->
<!-- - Other, please describe: -->


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying,
     or link to a relevant issue. -->
The namespace of the library is "chinook.AsyncWebView"

## What is the new behavior?
<!-- Please describe the new behavior after your modifications. -->
The namespace of the library is "Chinook.AsyncWebView"

## Checklist

Please check if your PR fulfills the following requirements:

- [ ] Documentation has been added/updated
- [ ] Automated Unit / Integration tests for the changes have been added/updated
- [ ] Contains **NO** breaking changes
- [ ] Updated the Changelog
- [ ] Associated with an issue

<!-- If this PR contains a breaking change, please describe the impact
     and migration path for existing applications below. -->


## Other information
<!-- Please provide any additional information if necessary -->

